### PR TITLE
Symlinks are not being followed

### DIFF
--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -273,6 +273,7 @@ sub find_files {
     { # for the benefit of perl 5.6.1's Find, localize topic
         local $_;
         File::Find::find( { no_chdir => 1, 
+                            follow => 1, 
                            wanted => sub { 
                              # Inlined from File::Find::Rule C< name => '*.pm' >
                              return unless $File::Find::name =~ /$file_regex/;


### PR DESCRIPTION
The use of File::Find in Module::Pluggable::Object does not use the follow=>1 option.  This means that if any of the paths in @INC are symlinks they will be silently ignored.  When perl analyzes @INC for require() and use() it _does_ follow symlinks, and I think Module::Pluggable should do the same.
