### PR TITLE
add warning of future removal from Perl core

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -33,6 +33,7 @@ my $build = Module::Build
   ->new( module_name => "Module::Pluggable",
          license     => 'perl',
          requires    => {
+             'if'              => '0',
              'File::Basename'  => '0',
              'File::Spec'      => '3.00',
          },

--- a/lib/Devel/InnerPackage.pm
+++ b/lib/Devel/InnerPackage.pm
@@ -4,6 +4,8 @@ use strict;
 use base qw(Exporter);
 use vars qw($VERSION @EXPORT_OK);
 
+use if $] > 5.017, 'deprecate';
+
 $VERSION = '0.4';
 @EXPORT_OK = qw(list_packages);
 

--- a/lib/Module/Pluggable.pm
+++ b/lib/Module/Pluggable.pm
@@ -4,6 +4,8 @@ use strict;
 use vars qw($VERSION $FORCE_SEARCH_ALL_PATHS);
 use Module::Pluggable::Object;
 
+use if $] > 5.017, 'deprecate';
+
 # ObQuote:
 # Bob Porter: Looks like you've been missing a lot of work lately. 
 # Peter Gibbons: I wouldn't say I've been missing it, Bob! 

--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -8,6 +8,8 @@ use Carp qw(croak carp confess);
 use Devel::InnerPackage;
 use vars qw($VERSION);
 
+use if $] > 5.017, 'deprecate';
+
 $VERSION = '4.5';
 
 


### PR DESCRIPTION
Module::Pluggable, along with a slew of other libraries added during the 5.9.x series to support CPANPLUS, is scheduled for removal for the core along with CPANPLUS itself.

This commit will add a warning when Module::Pluggable is used from its installed-with-perl location on perls 5.17.0 and greater.  Once the user installs Module::Pluggable from CPAN, the warning will stop.

Once this module is released and merged into core, no further updates to Module::Pluggable in core are likely to occur.  It would be great if this could be released "soon" so it can be merged back to core ASAP.

Thanks!
