### PR TITLE
Don't inherit from Exporter, but import its 'import'

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -36,6 +36,7 @@ my $build = Module::Build
              'if'              => '0',
              'File::Basename'  => '0',
              'File::Spec'      => '3.00',
+             'Exporter'        => '5.57',  # use Exporter 'import'
          },
          configure_requires => {
               'Module::Build'  => '0.38', 

--- a/lib/Devel/InnerPackage.pm
+++ b/lib/Devel/InnerPackage.pm
@@ -1,7 +1,7 @@
 package Devel::InnerPackage;
 
 use strict;
-use base qw(Exporter);
+use Exporter 5.57 'import';
 use vars qw($VERSION @EXPORT_OK);
 
 use if $] > 5.017, 'deprecate';


### PR DESCRIPTION
In `Devel::InnerPackage`, stop inheriting from `Exporter` and instead just import its `import` method.

This requires Exporter 5.57 which is in core since 5.8.3, but is also on CPAN.
Note that Module::Pluggable already depends on File::Spec 3.00 that appeared in core only in 5.8.6, so this doesn't change the dependencies for the crazy people that both use very old perls and avoid CPAN (do they still exist?).

[RT#98170](https://rt.cpan.org/Ticket/Display.html?id=98170)
