### PR TITLE
Use Module::Runtime::require_module

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -37,6 +37,7 @@ my $build = Module::Build
              'File::Basename'  => '0',
              'File::Spec'      => '3.00',
              'Exporter'        => '5.57',  # use Exporter 'import'
+             'Module::Runtime' => '0.012', # core bug workarounds
          },
          configure_requires => {
               'Module::Build'  => '0.38', 

--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -6,6 +6,7 @@ use File::Basename;
 use File::Spec::Functions qw(splitdir catdir curdir catfile abs2rel);
 use Carp qw(croak carp confess);
 use Devel::InnerPackage;
+use Module::Runtime qw(require_module);
 use vars qw($VERSION);
 
 use if $] > 5.017, 'deprecate';
@@ -280,7 +281,7 @@ sub handle_finding_plugin {
     $self->{before_require}->($plugin) || return if defined $self->{before_require};
     unless ($no_req) {
         my $tmp = $@;
-        my $res = eval { $self->_require($plugin) };
+        my $res = eval { require_module($plugin) };
         my $err = $@;
         $@      = $tmp;
         if ($err) {
@@ -354,16 +355,6 @@ sub handle_innerpackages {
     return @plugins;
 
 }
-
-
-sub _require {
-    my $self   = shift;
-    my $pack   = shift;
-    eval "CORE::require $pack";
-    die ($@) if $@;
-    return 1;
-}
-
 
 1;
 


### PR DESCRIPTION
Use [Module::Runtime](https://metacpan.org/pod/Module::Runtime)`::require_module` that is safer (no eval string) than our own module loading (`Module::Pluggable::Object::_require`) and has all known workarounds for core perl bugs.