### PR TITLE
Skip non-readable files in Module/Pluggable/Object.pm

### DIFF
--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -202,6 +202,7 @@ sub search_paths {
             my @pkg_dirs = ();
             if ( $name eq lc($name) || $name eq uc($name) ) {
                 my $pkg_file = catfile($sp, $directory, "$name$suffix");
+                next unless -r $pkg_file; # Skip files we can't read
                 open PKGFILE, "<$pkg_file" or die "search_paths: Can't open $pkg_file: $!";
                 my $in_pod = 0;
                 while ( my $line = <PKGFILE> ) {


### PR DESCRIPTION
This enables a poor man's authorization of plugins on file system
basis.

E.g., MooX::Cmd uses this module to discover subcommands.
Withdrawing read permission on files enables allowing different user
groups to execute different command sets without touching the code
at all.
