### PR TITLE
Convert to EUMM

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+2015-07-31 - 5.2
+    Convert to EUMM (Tim Orling)
+
 2014-01-05 - 5.1
     Add in missing files left out of the MANIFEST due to stupidity (thanks to Petr Pisar)
 

--- a/INSTALL
+++ b/INSTALL
@@ -1,9 +1,9 @@
 
 Same as practically every other Perl module ...
 
-        % perl Build.PL
-        % ./Build
-        % ./Build test
-        % sudo ./Build install
+        % perl Makefile.PL
+        % make
+        % make test
+        % sudo make install
 
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,3 @@
-Build.PL
 Changes
 INSTALL
 lib/Devel/InnerPackage.pm
@@ -7,8 +6,6 @@ lib/Module/Pluggable/Object.pm
 Makefile.PL
 MANIFEST			This list of files
 MANIFEST.SKIP
-META.json
-META.yml
 README
 t/01use.t
 t/02alsoworks.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,5 @@
 use strict;
-use Module::Build;
+use ExtUtils::MakeMaker;
 use FindBin;
 use File::Spec::Functions qw(catfile);
 
@@ -29,31 +29,30 @@ unless (grep { lc($^O) eq $_ } qw(vms vos)) {
     }
 }
 
-my $build = Module::Build
-  ->new( module_name => "Module::Pluggable",
-         license     => 'perl',
-         requires    => {
-             'if'              => '0',
-             'File::Basename'  => '0',
-             'File::Spec'      => '3.00',
-             'Exporter'        => '5.57',  # use Exporter 'import'
-         },
-         configure_requires => {
-              'Module::Build'  => '0.38', 
-         },
-         build_requires => {
-             'Test::More'      => '0.62',
-         },
-         create_makefile_pl    => 'small',
-         installdirs           => ((($] >= 5.008009) && ($] < 5.011)) ? 'core' : 'site'),
-         meta_merge     => {
-           resources => {
-             repository  => 'https://github.com/simonwistow/Module-Pluggable',
-           }
-         },
-       );
-
-$build->add_to_cleanup(@files);
-$build->build_elements([grep { $_ ne 'pod' } @{$build->build_elements}]) if $core;
-$build->create_build_script;
-
+WriteMakefile(
+    NAME => "Module::Pluggable",
+    VERSION_FROM => 'lib/Module/Pluggable.pm',
+    LICENSE => 'perl',
+    PREREQ_PM    => {
+        'if'              => '0',
+        'File::Basename'  => '0',
+        'File::Spec'      => '3.00',
+        'Exporter'        => '5.57',  # use Exporter 'import'
+    },
+    BUILD_REQUIRES => {
+        'Test::More'      => '0.62',
+    },
+    TEST_REQUIRES => {
+        'App::FatPacker'  >= '0.10.0',
+    },
+    clean => { FILES => @files },
+    META_MERGE     => {
+        resources => {
+            repository  => {
+                type => 'git',
+                url => 'git://github.com/simonwistow/Module-Pluggable',
+                web => 'https://github.com/simonwistow/Module-Pluggable',
+            },
+        },
+    },
+);

--- a/lib/Module/Pluggable.pm
+++ b/lib/Module/Pluggable.pm
@@ -11,7 +11,7 @@ use if $] > 5.017, 'deprecate';
 # Peter Gibbons: I wouldn't say I've been missing it, Bob! 
 
 
-$VERSION = '5.1';
+$VERSION = '5.2';
 $FORCE_SEARCH_ALL_PATHS = 0;
 
 sub import {


### PR DESCRIPTION
I have packaged your module for OpenEmbedded/Yocto Project [1], which has moved to Perl 5.22 and no longer supports Module::Build (which has been deprecated since Perl 5.19). This module will be blacklisted next week without this change.

[1] http://git.openembedded.org/meta-openembedded/tree/meta-perl/recipes-perl/libmodule/libmodule-pluggable-perl_5.1.bb