### PR TITLE
Use explicit plans instead of done_testing in tests.

### DIFF
--- a/t/27app_fatpacker.t
+++ b/t/27app_fatpacker.t
@@ -7,8 +7,11 @@ use Test::More;
 
 BEGIN {
     my $need_version = "0.10.0";
-    eval "use App::FatPacker $need_version ; 1; "
-      or plan skip_all => "App::FatPacker >= $need_version not available";
+    if (eval "use App::FatPacker $need_version ; 1;") {
+      plan tests => 2;
+    } else {
+      plan skip_all => "App::FatPacker >= $need_version not available";
+    }
 }
 
 use Cwd 'cwd';
@@ -50,8 +53,6 @@ $packed_file->close;
 
 # run it (and it's included tests )
 require_ok $packed_file;
-
-done_testing;
 
 sub copy_dir {
     my ($from, $to, $shift) = @_;


### PR DESCRIPTION
done_testing requires a newer Test::More than ships with older
perls.

Alternatively, add a test_requires that explicitly lists the correct minimum version of Test::More to use.

Module::Pluggable was only using done_testing in this one place though, so I think continuing to support older installations of Test::More is the right way to go here.
