### PR TITLE
Guard the can() call with blessed.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use 5.006;
 use strict;
 use warnings;
 
@@ -34,7 +35,7 @@ my %WriteMakefileArgs = (
     ABSTRACT_FROM       => 'lib/Module/Pluggable.pm',
     AUTHOR              => 'Simon Wistow <simon@thegestalt.org>',
     LICENSE             => 'perl_5',
-    MIN_PERL_VERSION    => '5.00503',
+    MIN_PERL_VERSION    => '5.006',
     INSTALLDIRS         => ($] >= 5.008009 && $] <= 5.011000 ? 'perl' : 'site'),
 
     CONFIGURE_REQUIRES => {
@@ -48,6 +49,7 @@ my %WriteMakefileArgs = (
         'File::Find'            => '0',
         'File::Spec::Functions' => '0',
         'strict'                => '0',
+        'Scalar::Util'          => '0',
     },
     TEST_REQUIRES => {
         'Test::More'            => '0',

--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -6,6 +6,7 @@ use File::Basename;
 use File::Spec::Functions qw(splitdir catdir curdir catfile abs2rel);
 use Carp qw(croak carp confess);
 use Devel::InnerPackage;
+use Scalar::Util qw( blessed );
 use vars qw($VERSION $MR);
 
 use if $] > 5.017, 'deprecate';
@@ -343,7 +344,7 @@ sub handle_inc_hooks {
 
     my @plugins;
     for my $dir ( @SEARCHDIR ) {
-        next unless ref $dir && eval { $dir->can( 'files' ) };
+        next unless blessed( $dir ) && $dir->can( 'files' );
 
         foreach my $plugin ( $dir->files ) {
             $plugin =~ s/\.pm$//;


### PR DESCRIPTION
With too many call frames under a web server, the eval call might get caught by an error handler
and elevated to a real error, masking the real error happened elsewhere.

Since this also needs to bring in the Scalar::Util::blessed() as a dependency,
the minimum perl version needs to be 5.6 at least.