### PR TITLE
Ignore the .AppleDouble/ directories that Mac OS leaves all over the place

### DIFF
--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -165,6 +165,8 @@ sub _is_legit {
     return 0 if     defined $self->{max_depth} && $depth>$self->{max_depth};
     return 0 if     defined $self->{min_depth} && $depth<$self->{min_depth};
 
+    return 0 if     $plugin =~ /(^|::).AppleDouble/;
+
     return 1;
 }
 

--- a/t/28appledouble.t
+++ b/t/28appledouble.t
@@ -1,0 +1,26 @@
+#!perl -w
+
+use strict;
+use FindBin;
+use lib (($FindBin::Bin."/lib")=~/^(.*)$/);
+use Test::More tests => 3;
+
+my @expected = qw(Apple::Double::Plugin::File);
+
+ok(my $foo = Apple::Double->new());
+ok(my @plugins = sort $foo->plugins);
+is_deeply(\@plugins, \@expected, "is deeply");
+
+package Apple::Double;
+
+use strict;
+use warnings;
+use Module::Pluggable;
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+
+}
+1;
+

--- a/t/lib/Apple/Double/Plugin/.AppleDouble/File.pm
+++ b/t/lib/Apple/Double/Plugin/.AppleDouble/File.pm
@@ -1,0 +1,1 @@
+this isn't a module

--- a/t/lib/Apple/Double/Plugin/File.pm
+++ b/t/lib/Apple/Double/Plugin/File.pm
@@ -1,0 +1,1 @@
+package Apple::Double::File;1;


### PR DESCRIPTION
If you have Foo/Bar.pm and even look at it on a Mac it will create Foo/.AppleDouble/Bar.pm, which is some binary nonsense and definitely not a module. This little patch makes Module::Pluggable skip them, and thus suppresses warnings about trying to load bogus files.