### PR TITLE
search_dirs_strict: only search the given search_dirs

### DIFF
--- a/lib/Module/Pluggable.pm
+++ b/lib/Module/Pluggable.pm
@@ -185,6 +185,8 @@ or directory
 
     use Module::Pluggable search_dirs => ['mylibs/Foo'];
 
+If you I<only> want to search those C<search_dirs>, provide a true value for
+C<search_dirs_strict>.
 
 Or if you want to instantiate each plugin rather than just return the name
 

--- a/lib/Module/Pluggable/Object.pm
+++ b/lib/Module/Pluggable/Object.pm
@@ -80,6 +80,13 @@ sub plugins {
     # check to see if we're running under test
     my @SEARCHDIR = exists $INC{"blib.pm"} && defined $filename && $filename =~ m!(^|/)blib/! && !$self->{'force_search_all_paths'} ? grep {/blib/} @INC : @INC;
 
+    if ($self->{'search_dirs_strict'}) {
+        die "search_dirs_strict: makes no sense without setting search_dirs"
+            unless $self->{'search_dirs'};
+
+        @SEARCHDIR = ();
+    }
+
     # add any search_dir params
     unshift @SEARCHDIR, @{$self->{'search_dirs'}} if defined $self->{'search_dirs'};
 

--- a/t/search_dirs_strict.t
+++ b/t/search_dirs_strict.t
@@ -1,0 +1,48 @@
+#!perl -w
+
+use strict;
+use FindBin;
+use Test::More tests => 3;
+
+SKIP: {
+
+my $inc = IncTest->new();
+
+$inc->plugins;
+
+ok($inc->required() > 0,'before_instantiate fired');
+
+# In other words, we only required Text::Abbrev, not all the other random
+# Text:: stuff from a standard @INC.
+is_deeply(
+  [ $inc->required ],
+  [ 'Text::Abbrev' ],
+  'we only required the expected library',
+);
+
+my ($ta) = $inc->required;
+is($ta->MPCHECK, 'HELLO', 'we got our version of Text::Abbrev');
+
+};
+
+package IncTest;
+our %REQUIRED;
+
+use Module::Pluggable search_path => "Text",
+                      search_dirs => "t/lib",
+                      search_dirs_strict => 1,
+                      require => 1,
+                      after_require  => sub { $REQUIRED{$_[0]} = 1 },
+                      on_require_error     => sub { };
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+}
+
+sub required {
+  my @req = sort keys %REQUIRED;
+  return @req;
+}
+
+1;


### PR DESCRIPTION
...as opposed to making them appear earlier in the search path.